### PR TITLE
Allow change window used to draw the overlay through builder

### DIFF
--- a/coachmarks/build.gradle
+++ b/coachmarks/build.gradle
@@ -46,7 +46,7 @@ project.afterEvaluate {
                 from components.release
                 groupId = "com.aolivafaura"
                 artifactId = "flex-coachmarks"
-                version = "1.0.18"
+                version = "1.0.20"
             }
         }
     }

--- a/coachmarks/src/main/java/com/aoliva/coachmarks/CoachMarksFlow.kt
+++ b/coachmarks/src/main/java/com/aoliva/coachmarks/CoachMarksFlow.kt
@@ -10,6 +10,7 @@ import android.util.Log
 import android.view.View
 import android.view.View.OnLayoutChangeListener
 import android.view.ViewGroup
+import android.view.Window
 import android.widget.ImageView
 import android.widget.RelativeLayout
 import androidx.constraintlayout.widget.ConstraintLayout
@@ -51,6 +52,7 @@ class CoachMarksFlow @JvmOverloads constructor(
 
     private var closeView: View? = null
     private var closeViewPosition: CloseViewPosition = CloseViewPosition.TOP_END
+    private var window: Window? = null
 
     /**
      * Notifies when coachmark view is dismissed
@@ -68,8 +70,8 @@ class CoachMarksFlow @JvmOverloads constructor(
         animate = builder.animate
         animationVelocity = builder.animationVelocity
         allowOverlaidViewsInteractions = builder.allowOverlaidInteractions
-        isRtl =
-            getActivity()?.window?.decorView?.layoutDirection == View.LAYOUT_DIRECTION_RTL || TextUtilsCompat.getLayoutDirectionFromLocale(
+        window = builder.window ?: getActivity()?.window
+        isRtl = window?.decorView?.layoutDirection == View.LAYOUT_DIRECTION_RTL || TextUtilsCompat.getLayoutDirectionFromLocale(
                 context.resources.configuration.locale
             ) == ViewCompat.LAYOUT_DIRECTION_RTL || builder.forceRtl
         closeView = builder.closeView
@@ -145,7 +147,7 @@ class CoachMarksFlow @JvmOverloads constructor(
 
     fun show() {
         Handler(Looper.getMainLooper()).postDelayed({
-            val vg = getActivity()?.window?.decorView?.rootView as ViewGroup
+            val vg = window?.decorView?.rootView as ViewGroup
             val params = LayoutParams(
                 ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.MATCH_PARENT
             )
@@ -520,6 +522,7 @@ class CoachMarksFlow @JvmOverloads constructor(
         internal var forceRtl = false
         internal var closeView: View? = null
         internal var closeViewPosition: CloseViewPosition? = null
+        internal var window: Window? = null
 
         fun steps(listSteps: List<Coachmark>) = apply { steps.addAll(listSteps) }
         fun nextStep(step: Coachmark) = apply { steps.add(step) }
@@ -539,6 +542,7 @@ class CoachMarksFlow @JvmOverloads constructor(
 
         fun closeViewPosition(position: CloseViewPosition = CloseViewPosition.TOP_END) =
             apply { this.closeViewPosition = position }
+        fun window(window: Window) = apply { this.window = window }
 
         fun build() = CoachMarksFlow(context).initView(this)
     }


### PR DESCRIPTION
Purpose: 

Libray needs to be able to draw the overlay over dialogues, for that the CoachMarksFlow.Builder allows a new parameter: 

![image](https://user-images.githubusercontent.com/11458794/150314808-f3155bea-c82f-45c4-9fe6-33444ddf8594.png)
